### PR TITLE
Create API endpoint to /api/v1/users and user creation

### DIFF
--- a/infra/controllers.js
+++ b/infra/controllers.js
@@ -1,4 +1,8 @@
-import { InternalServerError, MethodNotAllowedError, ValidationError } from "./errors";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ValidationError,
+} from "./errors";
 
 function onNoMatchHandler(req, res) {
   const publicErrorObject = new MethodNotAllowedError();

--- a/infra/controllers.js
+++ b/infra/controllers.js
@@ -1,6 +1,7 @@
 import {
   InternalServerError,
   MethodNotAllowedError,
+  NotFoundError,
   ValidationError,
 } from "./errors";
 
@@ -10,7 +11,7 @@ function onNoMatchHandler(req, res) {
 }
 
 function onErrorHandler(error, req, res) {
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
     return res.status(error.statusCode).json(error);
   }
 

--- a/infra/controllers.js
+++ b/infra/controllers.js
@@ -1,4 +1,4 @@
-import { InternalServerError, MethodNotAllowedError } from "./errors";
+import { InternalServerError, MethodNotAllowedError, ValidationError } from "./errors";
 
 function onNoMatchHandler(req, res) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -6,12 +6,16 @@ function onNoMatchHandler(req, res) {
 }
 
 function onErrorHandler(error, req, res) {
+  if (error instanceof ValidationError) {
+    return res.status(error.statusCode).json(error);
+  }
+
   const publicObjectError = new InternalServerError({
     statusCode: error.statusCode,
     cause: error,
   });
 
-  console.log(error);
+  console.error(publicObjectError);
 
   res.status(publicObjectError.statusCode).json(publicObjectError);
 }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -56,3 +56,23 @@ export class ServiceError extends Error {
     };
   }
 }
+
+export class ValidationError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Um erro de validação ocorreu.", {
+      cause,
+    });
+    this.name = "ValidationError";
+    this.action = action || "Ajuste os dados enviados e tente novamente.";
+    this.statusCode = 400;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -83,7 +83,8 @@ export class NotFoundError extends Error {
       cause,
     });
     this.name = "NotFoundError";
-    this.action = action || "Verifique se os parâmetros enviados na consulta estão certos.";
+    this.action =
+      action || "Verifique se os parâmetros enviados na consulta estão certos.";
     this.statusCode = 404;
   }
 

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -76,3 +76,23 @@ export class ValidationError extends Error {
     };
   }
 }
+
+export class NotFoundError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Não foi possível encontrar esse recurso no sistema.", {
+      cause,
+    });
+    this.name = "NotFoundError";
+    this.action = action || "Verifique se os parâmetros enviados na consulta estão certos.";
+    this.statusCode = 404;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/infra/migrations/1770247531451_first-migration-test.js
+++ b/infra/migrations/1770247531451_first-migration-test.js
@@ -1,8 +1,0 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
-exports.up = (pgm) => {};
-
-exports.down = (pgm) => {};

--- a/infra/migrations/1775602822562_create-users.js
+++ b/infra/migrations/1775602822562_create-users.js
@@ -1,0 +1,40 @@
+exports.up = (pgm) => {
+  pgm.createTable("users", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+    // For reference GiHub limits usernames to 39 characters
+    username: {
+      type: "varchar(30)",
+      notNull: true,
+      unique: true,
+    },
+    // https://stackoverflow.com/a/1199238
+    email: {
+      type: "varchar(254)",
+      notNull: true,
+      unique: true,
+    },
+    // https://www.npmjs.com/package/bcrypt#hash-info
+    password: {
+      type: "varchar(60)",
+      notNull: true,
+    },
+    // https://justatheory.com/2012/04/postgres-use-timestamptz/
+    created_at: {
+      type: "timestamptz",
+      default: pgm.func("timezone('utc', now())"),
+      notNull: true,
+    },
+    // https://justatheory.com/2012/04/postgres-use-timestamptz/
+    updated_at: {
+      type: "timestamptz",
+      default: pgm.func("timezone('utc', now())"),
+      notNull: true,
+    },
+  });
+};
+
+exports.down = false;

--- a/model/migrator.js
+++ b/model/migrator.js
@@ -6,7 +6,7 @@ const defaultMigrationOptions = {
   dryRun: true,
   dir: resolve("infra", "migrations"),
   direction: "up",
-  verbose: true,
+  log: () => {},
   migrationsTable: "pgmigrations",
 };
 

--- a/model/user.js
+++ b/model/user.js
@@ -1,0 +1,82 @@
+import database from "infra/database";
+import { ValidationError } from "infra/errors";
+
+async function create(userInputValues) {
+  await validateUniqueEmail(userInputValues.email);
+  await validateUniqueUsername(userInputValues.username);
+
+
+  const newUser = await runInsertQuery(userInputValues);
+  return newUser;
+
+  async function validateUniqueEmail(email) {
+    const result = await database.query({
+      text: `
+        SELECT 
+          email
+        FROM
+          users
+        WHERE
+          LOWER(email) = LOWER($1)
+        ;`,
+      values: [email],
+    })
+
+    if (result.rowCount > 0) {
+      throw new ValidationError({
+        message: "O e-mail informado já esta sendo utilizado",
+        action: "Utilize outro e-mail para realizar o cadastro"
+      })
+    }
+
+    return result.rows[0];
+  }
+
+    async function validateUniqueUsername(username) {
+    const result = await database.query({
+      text: `
+        SELECT 
+          username
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+        ;`,
+      values: [username],
+    })
+
+    if (result.rowCount > 0) {
+      throw new ValidationError({
+        message: "O username informado já esta sendo utilizado",
+        action: "Utilize outro username para realizar o cadastro"
+      })
+    }
+
+    return result.rows[0];
+  }
+
+  async function runInsertQuery(userInputValues) {
+    const { username, email, password } = userInputValues;
+
+    const result = await database.query({
+      text: `
+        INSERT INTO
+          users (username, email, password)
+        VALUES 
+          ($1, $2, $3)
+        RETURNING
+          *
+        `,
+      values: [username, email, password],
+    })
+
+
+    return result.rows[0];
+  }
+}
+
+const user = {
+  create,
+}
+
+export default user;

--- a/model/user.js
+++ b/model/user.js
@@ -5,7 +5,6 @@ async function create(userInputValues) {
   await validateUniqueEmail(userInputValues.email);
   await validateUniqueUsername(userInputValues.username);
 
-
   const newUser = await runInsertQuery(userInputValues);
   return newUser;
 
@@ -20,19 +19,19 @@ async function create(userInputValues) {
           LOWER(email) = LOWER($1)
         ;`,
       values: [email],
-    })
+    });
 
     if (result.rowCount > 0) {
       throw new ValidationError({
         message: "O e-mail informado já esta sendo utilizado",
-        action: "Utilize outro e-mail para realizar o cadastro"
-      })
+        action: "Utilize outro e-mail para realizar o cadastro",
+      });
     }
 
     return result.rows[0];
   }
 
-    async function validateUniqueUsername(username) {
+  async function validateUniqueUsername(username) {
     const result = await database.query({
       text: `
         SELECT 
@@ -43,13 +42,13 @@ async function create(userInputValues) {
           LOWER(username) = LOWER($1)
         ;`,
       values: [username],
-    })
+    });
 
     if (result.rowCount > 0) {
       throw new ValidationError({
         message: "O username informado já esta sendo utilizado",
-        action: "Utilize outro username para realizar o cadastro"
-      })
+        action: "Utilize outro username para realizar o cadastro",
+      });
     }
 
     return result.rows[0];
@@ -68,8 +67,7 @@ async function create(userInputValues) {
           *
         `,
       values: [username, email, password],
-    })
-
+    });
 
     return result.rows[0];
   }
@@ -77,6 +75,6 @@ async function create(userInputValues) {
 
 const user = {
   create,
-}
+};
 
 export default user;

--- a/model/user.js
+++ b/model/user.js
@@ -1,5 +1,5 @@
 import database from "infra/database";
-import { ValidationError } from "infra/errors";
+import { NotFoundError, ValidationError } from "infra/errors";
 
 async function create(userInputValues) {
   await validateUniqueEmail(userInputValues.email);
@@ -73,8 +73,39 @@ async function create(userInputValues) {
   }
 }
 
+async function findOneByUsername(username) {
+  const userFound = await runSelectQuery(username);
+
+  return userFound;
+
+    async function runSelectQuery(username) {
+    const result = await database.query({
+      text: `
+        SELECT 
+          *
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+        LIMIT 1
+        ;`,
+      values: [username],
+    });
+
+    if (result.rowCount === 0) {
+      throw new NotFoundError({
+        message: "O username informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado corretamente.",
+      });
+    }
+
+    return result.rows[0];
+  }
+}
+
 const user = {
   create,
+  findOneByUsername,
 };
 
 export default user;

--- a/model/user.js
+++ b/model/user.js
@@ -78,7 +78,7 @@ async function findOneByUsername(username) {
 
   return userFound;
 
-    async function runSelectQuery(username) {
+  async function runSelectQuery(username) {
     const result = await database.query({
       text: `
         SELECT 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "pg": "8.12.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "swr": "2.2.5"
+        "swr": "2.2.5",
+        "uuid": "11.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.4.0",
@@ -11655,6 +11656,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "pg": "8.12.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "swr": "2.2.5"
+    "swr": "2.2.5",
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.4.0",

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,0 +1,15 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controllers";
+import user from "model/user";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(req, res) {
+  const username = req.query.username;
+  const userFound = await user.findOneByUsername(username);
+  return res.status(200).json(userFound);
+}

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,0 +1,16 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controllers";
+import user from "model/user";
+
+const router = createRouter();
+
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+
+async function postHandler(req, res) {
+  const userInputValues = req.body;
+  const newUser = await user.create(userInputValues);
+  return res.status(201).json(newUser);
+}

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -8,7 +8,6 @@ router.post(postHandler);
 
 export default router.handler(controller.errorHandlers);
 
-
 async function postHandler(req, res) {
   const userInputValues = req.body;
   const newUser = await user.create(userInputValues);

--- a/tests/integrations/api/v1/users/[username]/get.test.js
+++ b/tests/integrations/api/v1/users/[username]/get.test.js
@@ -1,0 +1,105 @@
+import { version as uuidVersion } from "uuid";
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("GET /api/v1/users/[username]", () => {
+  describe("Anonymous user", () => {
+    test("With exact case match", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(
+          {
+            username: "testUser",
+            email: "test-user@email.com",
+            password: "123456",
+          },
+          null,
+          2,
+        ),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users/testUser");
+
+      expect(response2.status).toBe(200);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "testUser",
+        email: "test-user@email.com",
+        password: "123456",
+        updated_at: response2Body.updated_at,
+        created_at: response2Body.created_at,
+      });
+
+      expect(uuidVersion(response2Body.id)).toBe(4);
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN();
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+    });
+
+    test("With case mismatch", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(
+          {
+            username: "OtherCase",
+            email: "other-case@email.com",
+            password: "123456",
+          },
+          null,
+          2,
+        ),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users/othercase");
+
+      expect(response2.status).toBe(200);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "OtherCase",
+        email: "other-case@email.com",
+        password: "123456",
+        updated_at: response2Body.updated_at,
+        created_at: response2Body.created_at,
+      });
+
+      expect(uuidVersion(response2Body.id)).toBe(4);
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN();
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+    });
+
+    test("With nonexistent username", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/users/nonexistent");
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "NotFoundError",
+        message: "O username informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado corretamente.",
+        status_code: 404
+      });
+    });
+  });
+});

--- a/tests/integrations/api/v1/users/[username]/get.test.js
+++ b/tests/integrations/api/v1/users/[username]/get.test.js
@@ -28,7 +28,9 @@ describe("GET /api/v1/users/[username]", () => {
 
       expect(response1.status).toBe(201);
 
-      const response2 = await fetch("http://localhost:3000/api/v1/users/testUser");
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/testUser",
+      );
 
       expect(response2.status).toBe(200);
 
@@ -67,7 +69,9 @@ describe("GET /api/v1/users/[username]", () => {
 
       expect(response1.status).toBe(201);
 
-      const response2 = await fetch("http://localhost:3000/api/v1/users/othercase");
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/othercase",
+      );
 
       expect(response2.status).toBe(200);
 
@@ -88,7 +92,9 @@ describe("GET /api/v1/users/[username]", () => {
     });
 
     test("With nonexistent username", async () => {
-      const response = await fetch("http://localhost:3000/api/v1/users/nonexistent");
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/nonexistent",
+      );
 
       expect(response.status).toBe(404);
 
@@ -98,7 +104,7 @@ describe("GET /api/v1/users/[username]", () => {
         name: "NotFoundError",
         message: "O username informado não foi encontrado no sistema.",
         action: "Verifique se o username está digitado corretamente.",
-        status_code: 404
+        status_code: 404,
       });
     });
   });

--- a/tests/integrations/api/v1/users/post.test.js
+++ b/tests/integrations/api/v1/users/post.test.js
@@ -1,0 +1,121 @@
+import { version as uuidVersion } from "uuid";
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("POST /api/v1/users", () => {
+  describe("Anonymous user", () => {
+    test("With unique and valid data", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "test",
+          email: "test@email.com",
+          password: "123456"
+        }, null, 2)
+      });
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "test",
+        email: "test@email.com",
+        password: "123456",
+        updated_at: responseBody.updated_at,
+        created_at: responseBody.created_at,
+      })
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+    });
+
+    test("With duplicated 'email'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "email-duplicated-1",
+          email: "duplicated@email.com",
+          password: "123456"
+        }, null, 2)
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "email-duplicated-2",
+          email: "Duplicated@email.com",
+          password: "123456"
+        }, null, 2)
+      });
+
+      expect(response2.status).toBe(400);
+
+      const responseBody = await response2.json();
+
+      expect(responseBody).toEqual({
+        action: "Utilize outro e-mail para realizar o cadastro",
+        message: "O e-mail informado já esta sendo utilizado",
+        name: "ValidationError",
+        status_code: 400,
+      });
+    });
+
+    test("With duplicated 'username'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "username-duplicated",
+          email: "username1@email.com",
+          password: "123456"
+        }, null, 2)
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "username-duplicated",
+          email: "username2@email.com",
+          password: "123456"
+        }, null, 2)
+      });
+
+      expect(response2.status).toBe(400);
+
+      const responseBody = await response2.json();
+
+      expect(responseBody).toEqual({
+        action: "Utilize outro username para realizar o cadastro",
+        message: "O username informado já esta sendo utilizado",
+        name: "ValidationError",
+        status_code: 400,
+      });
+    });
+  });
+});

--- a/tests/integrations/api/v1/users/post.test.js
+++ b/tests/integrations/api/v1/users/post.test.js
@@ -15,11 +15,15 @@ describe("POST /api/v1/users", () => {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          username: "test",
-          email: "test@email.com",
-          password: "123456"
-        }, null, 2)
+        body: JSON.stringify(
+          {
+            username: "test",
+            email: "test@email.com",
+            password: "123456",
+          },
+          null,
+          2,
+        ),
       });
 
       expect(response.status).toBe(201);
@@ -33,7 +37,7 @@ describe("POST /api/v1/users", () => {
         password: "123456",
         updated_at: responseBody.updated_at,
         created_at: responseBody.created_at,
-      })
+      });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
       expect(Date.parse(responseBody.created_at)).not.toBeNaN();
@@ -46,11 +50,15 @@ describe("POST /api/v1/users", () => {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          username: "email-duplicated-1",
-          email: "duplicated@email.com",
-          password: "123456"
-        }, null, 2)
+        body: JSON.stringify(
+          {
+            username: "email-duplicated-1",
+            email: "duplicated@email.com",
+            password: "123456",
+          },
+          null,
+          2,
+        ),
       });
 
       expect(response1.status).toBe(201);
@@ -60,11 +68,15 @@ describe("POST /api/v1/users", () => {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          username: "email-duplicated-2",
-          email: "Duplicated@email.com",
-          password: "123456"
-        }, null, 2)
+        body: JSON.stringify(
+          {
+            username: "email-duplicated-2",
+            email: "Duplicated@email.com",
+            password: "123456",
+          },
+          null,
+          2,
+        ),
       });
 
       expect(response2.status).toBe(400);
@@ -85,11 +97,15 @@ describe("POST /api/v1/users", () => {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          username: "username-duplicated",
-          email: "username1@email.com",
-          password: "123456"
-        }, null, 2)
+        body: JSON.stringify(
+          {
+            username: "username-duplicated",
+            email: "username1@email.com",
+            password: "123456",
+          },
+          null,
+          2,
+        ),
       });
 
       expect(response1.status).toBe(201);
@@ -99,11 +115,15 @@ describe("POST /api/v1/users", () => {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          username: "username-duplicated",
-          email: "username2@email.com",
-          password: "123456"
-        }, null, 2)
+        body: JSON.stringify(
+          {
+            username: "username-duplicated",
+            email: "username2@email.com",
+            password: "123456",
+          },
+          null,
+          2,
+        ),
       });
 
       expect(response2.status).toBe(400);

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -29,7 +29,6 @@ async function runPendingMigrations() {
   await migrator.runPendingMigrations();
 }
 
-
 const orchestrator = {
   waitForAllServices,
   clearDatabase,

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,5 +1,6 @@
 import retry from "async-retry";
 import database from "infra/database";
+import migrator from "model/migrator";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -24,9 +25,15 @@ async function clearDatabase() {
   await database.query("drop schema public cascade; create schema public;");
 }
 
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations();
+}
+
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
+  runPendingMigrations,
 };
 
 export default orchestrator;


### PR DESCRIPTION
- Cria model `user`
- Cria 2 novos endpoints:
  - `POST` `/api/v1/users`
  - `GET` `/api/v1/users/[username]`
- Remove `migration` de teste
- Cria `migration` que cria a tabela `users`
- Cria dois novos erros customizados:
  - `ValidationError`
  - `NotFoundError`
- Adiciona novo método ao `orchestrator`:
  - `runPendingMigrations`
- Silencia os logs do `migrator`